### PR TITLE
Refactor and Add VSCode Configuration for Debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ nbdist/
 *.swn
 
 # Visual Studio Code
-.vscode/
 .history/
 .vscode-test/
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,46 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'binance_ws'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=binance_ws",
+                    "--package=binance_ws"
+                ],
+                "filter": {
+                    "name": "binance_ws",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "console": "externalTerminal"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'binance_ws'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=binance_ws",
+                    "--package=binance_ws"
+                ],
+                "filter": {
+                    "name": "binance_ws",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,5 +8,9 @@ use menu::show_menu;
 
 #[tokio::main]
 async fn main() {
-    show_menu().await;
+    let symbols = subscription::fetch_symbols().await;
+    match symbols {
+        Ok(symbols) => show_menu(&symbols).await,
+        Err(e) => eprintln!("Error fetching symbols: {}", e),
+    }
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,14 +1,14 @@
 use crate::storage::aggtrade_storage::AggTradeStorage;
-use crate::subscription::fetch_symbols;
 use crate::websocket::client::run::run;
 use crate::websocket::client::{BINANCE_WS_COMBINED_URL, BINANCE_WS_URL};
 use inquire::{MultiSelect, Select};
+use tokio::time::Sleep;
 use std::io::{self, Write};
 use std::sync::{Arc, RwLock};
 
 /// Displays the main menu and processes user selections
-pub async fn show_menu() {
-    let options = vec![
+pub async fn show_menu(symbols: &Vec<String>) {
+    const OPTIONS: [&str; 7] = [
         "Subscribe to aggTrade",
         "Subscribe to trade",
         "Subscribe to kline",
@@ -26,16 +26,16 @@ pub async fn show_menu() {
         println!("       Binance WebSocket      ");
         println!("==============================");
 
-        let choice = Select::new("Choose an option:", options.clone()).prompt();
+        let choice = Select::new("Choose an option:", OPTIONS.to_vec()).prompt();
 
         match choice {
             Ok(option) => match option {
-                "Subscribe to aggTrade" => subscribe("aggTrade", storage.clone()).await,
-                "Subscribe to trade" => subscribe("trade", storage.clone()).await,
-                "Subscribe to kline" => subscribe_with_interval("kline", storage.clone()).await,
-                "Custom Subscribe" => custom_subscribe(storage.clone()).await,
-                "List Symbols" => list_symbols().await,
-                "List Subscriptions" => list_subscriptions(storage.clone()),
+                "Subscribe to aggTrade" => subscribe("aggTrade", &storage, symbols).await,
+                "Subscribe to trade" => subscribe("trade", &storage, symbols).await,
+                "Subscribe to kline" => subscribe_with_interval("kline", &storage, symbols).await,
+                "Custom Subscribe" => custom_subscribe(&storage, symbols).await,
+                "List Symbols" => list_symbols(symbols),
+                "List Subscriptions" => list_subscriptions(&storage),
                 "Exit" => break,
                 _ => unreachable!(),
             },
@@ -48,83 +48,72 @@ pub async fn show_menu() {
 }
 
 /// Subscribes to a single stream type (aggTrade, trade)
-async fn subscribe(stream_type: &str, storage: Arc<RwLock<AggTradeStorage>>) {
-    if let Ok(symbols) = fetch_symbols().await {
-        if let Some(symbol) = select_symbol(symbols).await {
-            let url = format!("{}{}@{}", BINANCE_WS_URL, symbol, stream_type);
-            process_subscription(&url, vec![format!("{}@{}", symbol, stream_type)], storage).await;
-        }
-    } else {
-        eprintln!("Failed to fetch symbols.");
+async fn subscribe(stream_type: &str, storage: &Arc<RwLock<AggTradeStorage>>, symbols: &Vec<String>) {
+    if let Some(symbol) = select_symbol(symbols) {
+        let url = format!("{}{}@{}", BINANCE_WS_URL, symbol, stream_type);
+        process_subscription(&url, &vec![format!("{}@{}", symbol, stream_type)], storage).await;
     }
 }
 
 /// Subscribes to a stream type with interval (kline)
-async fn subscribe_with_interval(stream_type: &str, storage: Arc<RwLock<AggTradeStorage>>) {
-    if let Ok(symbols) = fetch_symbols().await {
-        if let Some(symbol) = select_symbol(symbols).await {
-            let intervals = vec![
-                "1s", "1m", "3m", "5m", "15m", "30m", "1h", "2h", "4h", "6h", "8h", "12h", "1d",
-                "3d", "1w", "1M",
-            ];
-            if let Some(interval) = select_interval(intervals).await {
-                let url = format!("{}{}@{}_{}", BINANCE_WS_URL, symbol, stream_type, interval);
-                process_subscription(
-                    &url,
-                    vec![format!("{}@{}_{}", symbol, stream_type, interval)],
-                    storage,
-                )
-                .await;
-            }
+async fn subscribe_with_interval(stream_type: &str, storage: &Arc<RwLock<AggTradeStorage>>, symbols: &Vec<String>) {
+    let symbol_selection = select_symbol(symbols);
+    if let Some(symbol) = symbol_selection {
+        const INTERVALS: [&str; 16] = [
+            "1s", "1m", "3m", "5m", "15m", "30m", "1h", "2h", "4h", "6h", "8h", "12h", "1d",
+            "3d", "1w", "1M",
+        ];
+        if let Some(interval) = select_interval(INTERVALS.to_vec()) {
+            let url = format!("{}{}@{}_{}", BINANCE_WS_URL, symbol, stream_type, interval);
+            process_subscription(
+                &url,
+                &vec![format!("{}@{}_{}", symbol, stream_type, interval)],
+                storage,
+            )
+            .await;
         }
-    } else {
-        eprintln!("Failed to fetch symbols.");
     }
 }
 
 /// Subscribes to multiple custom streams
-async fn custom_subscribe(storage: Arc<RwLock<AggTradeStorage>>) {
-    if let Ok(symbols) = fetch_symbols().await {
-        let selected_symbols = MultiSelect::new("Choose symbols:", symbols)
-            .prompt()
-            .unwrap_or_default();
-        let stream_types = vec!["aggTrade", "trade", "kline"];
-        let selected_streams = MultiSelect::new("Choose stream types:", stream_types)
-            .prompt()
-            .unwrap_or_default();
+async fn custom_subscribe(storage: &Arc<RwLock<AggTradeStorage>>, symbols: &Vec<String>) {
+    let selected_symbols = MultiSelect::new("Choose symbols:", symbols.to_vec())
+        .prompt()
+        .unwrap_or_default();
+    let stream_types = vec!["aggTrade", "trade", "kline"];
+    let selected_streams = MultiSelect::new("Choose stream types:", stream_types)
+        .prompt()
+        .unwrap_or_default();
 
-        let mut streams = Vec::new();
-        for stream in &selected_streams {
-            if *stream == "kline" {
-                let intervals = vec![
-                    "1s", "1m", "3m", "5m", "15m", "30m", "1h", "2h", "4h", "6h", "8h", "12h",
-                    "1d", "3d", "1w", "1M",
-                ];
-                if let Some(interval) = select_interval(intervals).await {
-                    for symbol in &selected_symbols {
-                        streams.push(format!("{}@{}_{}", symbol, stream, interval));
-                    }
-                }
-            } else {
+    let mut streams = Vec::new();
+    for stream in &selected_streams {
+        if *stream == "kline" {
+            const INTERVALS: [&str; 16] = [
+                "1s", "1m", "3m", "5m", "15m", "30m", "1h", "2h", "4h", "6h", "8h", "12h",
+                "1d", "3d", "1w", "1M",
+            ];
+            if let Some(interval) = select_interval(INTERVALS.to_vec()) {
                 for symbol in &selected_symbols {
-                    streams.push(format!("{}@{}", symbol, stream));
+                    streams.push(format!("{}@{}_{}", symbol, stream, interval));
                 }
             }
+        } else {
+            for symbol in &selected_symbols {
+                streams.push(format!("{}@{}", symbol, stream));
+            }
         }
-
-        let combined_streams = streams.join("/");
-        let url = format!("{}{}", BINANCE_WS_COMBINED_URL, combined_streams);
-        process_subscription(&url, streams, storage).await;
-    } else {
-        eprintln!("Failed to fetch symbols.");
     }
+
+    let combined_streams = streams.join("/");
+    let url = format!("{}{}", BINANCE_WS_COMBINED_URL, combined_streams);
+    process_subscription(&url, &streams, storage).await;
 }
 
 /// Processes the WebSocket subscription
 async fn process_subscription(
     url: &str,
-    streams: Vec<String>,
-    storage: Arc<RwLock<AggTradeStorage>>,
+    streams: &Vec<String>,
+    storage: &Arc<RwLock<AggTradeStorage>>,
 ) {
     clear_screen();
     println!("Subscribing to streams...");
@@ -137,18 +126,18 @@ async fn process_subscription(
 }
 
 /// Waits for shutdown signal and completes all tasks
-async fn wait_for_shutdown() {
+fn wait_for_shutdown() -> Sleep {
     // Wait for a small amount of time to ensure all tasks complete
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    return tokio::time::sleep(tokio::time::Duration::from_millis(100));
 }
 
 /// Selects a symbol from the list of symbols
-async fn select_symbol(symbols: Vec<String>) -> Option<String> {
-    Select::new("Choose a symbol:", symbols).prompt().ok()
+fn select_symbol(symbols: &Vec<String>) -> Option<String> {
+    Select::new("Choose a symbol:", symbols.to_vec()).prompt().ok()
 }
 
 /// Selects an interval from the list of intervals
-async fn select_interval(intervals: Vec<&str>) -> Option<String> {
+fn select_interval(intervals: Vec<&str>) -> Option<String> {
     Select::new("Choose an interval:", intervals)
         .prompt()
         .ok()
@@ -156,24 +145,21 @@ async fn select_interval(intervals: Vec<&str>) -> Option<String> {
 }
 
 /// Lists all available symbols
-async fn list_symbols() {
+fn list_symbols(symbols: &Vec<String>) {
     clear_screen();
-    if let Ok(symbols) = fetch_symbols().await {
-        println!("Available symbols:");
-        for symbol in symbols {
-            println!("{}", symbol);
-        }
-    } else {
-        eprintln!("Failed to fetch symbols.");
+    println!("Available symbols:");
+    for symbol in symbols {
+        println!("{}", symbol);
     }
     pause();
 }
 
 /// Lists current subscriptions (placeholder)
-fn list_subscriptions(storage: Arc<RwLock<AggTradeStorage>>) {
+fn list_subscriptions(storage: &Arc<RwLock<AggTradeStorage>>) {
     clear_screen();
     println!("Listing subscriptions...");
-    let trades = storage.read().unwrap().get_trades();
+    let read = storage.read().unwrap();
+    let trades = read.get_trades();
     for trade in trades {
         println!("{:?}", trade);
     }

--- a/src/storage/aggtrade_storage.rs
+++ b/src/storage/aggtrade_storage.rs
@@ -119,8 +119,8 @@ impl AggTradeStorage {
     }
 
     // Get all trades
-    pub fn get_trades(&self) -> Vec<AggTrade> {
-        self.trades.iter().cloned().collect()
+    pub fn get_trades(&self) -> &VecDeque<AggTrade> {
+        &self.trades
     }
 
     // Calculate the average price of trades

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -12,8 +12,8 @@ struct ExchangeInfo {
 }
 
 pub async fn fetch_symbols() -> Result<Vec<String>, Error> {
-    let url = "https://api.binance.com/api/v3/exchangeInfo";
-    let response = reqwest::get(url).await?.json::<ExchangeInfo>().await?;
+    const URL: &str = "https://api.binance.com/api/v3/exchangeInfo";
+    let response = reqwest::get(URL).await?.json::<ExchangeInfo>().await?;
     Ok(response
         .symbols
         .into_iter()

--- a/src/websocket/client/run.rs
+++ b/src/websocket/client/run.rs
@@ -11,43 +11,32 @@ use tokio_tungstenite::connect_async;
 
 pub async fn run(
     url: &str,
-    streams: Vec<String>,
+    streams: &Vec<String>,
     base_id: u64,
-    storage: Arc<RwLock<AggTradeStorage>>,
+    storage: &Arc<RwLock<AggTradeStorage>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
-    let (ws_shutdown_tx, ws_shutdown_rx) = oneshot::channel();
-
-    // Clone storage to move into async block
-    let storage_clone = Arc::clone(&storage);
+    let (shutdown_tx, mut shutdown_rx) = mpsc::channel(1);
+    let (_, mut ws_shutdown_rx) = oneshot::channel();
 
     // Spawn a task to handle shutdown
     tokio::spawn(async move {
-        handle_shutdown(shutdown_tx).await;
+        handle_shutdown(&shutdown_tx).await;
     });
 
     // Connect to WebSocket
     let (ws_stream, _) = connect_async(url).await?;
     println!("WebSocket connected");
 
-    let (mut write, read) = ws_stream.split();
+    let (mut write, mut read) = ws_stream.split();
 
     // Subscribe to streams
     subscribe_to_streams(&mut write, &streams, base_id).await?;
-
-    // Handle incoming messages
-    let handle = tokio::spawn(async move {
-        handle_aggtrade_messages(read, storage_clone, shutdown_rx).await;
-        let _ = ws_shutdown_tx.send(());
-    });
-
     // Start ping
-    start_ping(&mut write, ws_shutdown_rx).await;
-
+    start_ping(&mut write, &mut ws_shutdown_rx).await;
+    // Await the handle to ensure proper handling
+    handle_aggtrade_messages(&mut read, &storage, &mut shutdown_rx).await;
     // Unsubscribe from streams
     unsubscribe_from_streams(&mut write, &streams, base_id + 1000).await?;
 
-    // Await the handle to ensure proper handling
-    handle.await?;
     Ok(())
 }

--- a/src/websocket/client/subscribe.rs
+++ b/src/websocket/client/subscribe.rs
@@ -5,7 +5,7 @@ use tokio_tungstenite::tungstenite::protocol::Message;
 /// Subscribe to specified streams.
 pub async fn subscribe_to_streams<S>(
     write: &mut S,
-    streams: &[String],
+    streams: &Vec<String>,
     base_id: u64,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
@@ -13,7 +13,7 @@ where
     <S as futures_util::Sink<Message>>::Error: std::error::Error + 'static,
 {
     // Create the subscription message.
-    let subscribe_msg = subscribe_message(streams.to_vec(), base_id);
+    let subscribe_msg = subscribe_message(streams, base_id);
     println!("Subscribe Payload: {}", subscribe_msg);
 
     // Send the subscription message.

--- a/src/websocket/client/unsubscribe.rs
+++ b/src/websocket/client/unsubscribe.rs
@@ -5,7 +5,7 @@ use tokio_tungstenite::tungstenite::protocol::Message;
 /// Unsubscribe from specified streams.
 pub async fn unsubscribe_from_streams<S>(
     write: &mut S,
-    streams: &[String],
+    streams: &Vec<String>,
     base_id: u64,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
@@ -13,7 +13,7 @@ where
     <S as futures_util::Sink<Message>>::Error: std::error::Error + 'static,
 {
     // Create the unsubscription message.
-    let unsubscribe_msg = unsubscribe_message(streams.to_vec(), base_id);
+    let unsubscribe_msg = unsubscribe_message(streams, base_id);
     println!("Unsubscribe Payload: {}", unsubscribe_msg);
 
     // Send the unsubscription message.

--- a/src/websocket/handler/aggtrade_handler.rs
+++ b/src/websocket/handler/aggtrade_handler.rs
@@ -17,9 +17,9 @@ use tui::backend::CrosstermBackend;
 use tui::Terminal;
 
 pub async fn handle_aggtrade_messages<S>(
-    mut read: S,
-    storage: Arc<RwLock<AggTradeStorage>>,
-    mut shutdown_rx: mpsc::Receiver<()>,
+    read: &mut S,
+    storage: &Arc<RwLock<AggTradeStorage>>,
+    shutdown_rx: &mut mpsc::Receiver<()>,
 ) where
     S: StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
 {

--- a/src/websocket/shutdown.rs
+++ b/src/websocket/shutdown.rs
@@ -1,6 +1,6 @@
 use tokio::sync::mpsc::Sender;
 
-pub async fn handle_shutdown(shutdown_tx: Sender<()>) {
+pub async fn handle_shutdown(shutdown_tx: &Sender<()>) {
     // Wait for Ctrl+C signal
     tokio::signal::ctrl_c().await.unwrap();
     // Send shutdown signal

--- a/src/websocket/subscriptions.rs
+++ b/src/websocket/subscriptions.rs
@@ -1,4 +1,4 @@
-pub fn subscribe_message(streams: Vec<String>, id: u64) -> String {
+pub fn subscribe_message(streams: &Vec<String>, id: u64) -> String {
     // Create subscribe message as a JSON string
     serde_json::json!({
         "method": "SUBSCRIBE",
@@ -8,7 +8,7 @@ pub fn subscribe_message(streams: Vec<String>, id: u64) -> String {
     .to_string()
 }
 
-pub fn unsubscribe_message(streams: Vec<String>, id: u64) -> String {
+pub fn unsubscribe_message(streams: &Vec<String>, id: u64) -> String {
     // Create unsubscribe message as a JSON string
     serde_json::json!({
         "method": "UNSUBSCRIBE",
@@ -28,7 +28,7 @@ mod tests {
         // Test for subscribe message creation
         let streams = vec!["btcusdt@aggTrade".to_string(), "ethusdt@trade".to_string()];
         let id = 1;
-        let message = subscribe_message(streams.clone(), id);
+        let message = subscribe_message(&streams, id);
         let expected_message = json!({
             "method": "SUBSCRIBE",
             "params": streams,
@@ -43,7 +43,7 @@ mod tests {
         // Test for unsubscribe message creation
         let streams = vec!["btcusdt@aggTrade".to_string(), "ethusdt@trade".to_string()];
         let id = 1;
-        let message = unsubscribe_message(streams.clone(), id);
+        let message = unsubscribe_message(&streams, id);
         let expected_message = json!({
             "method": "UNSUBSCRIBE",
             "params": streams,


### PR DESCRIPTION
- Added `.vscode/launch.json` for configuring debugging sessions in VSCode.
  - Configured for debugging executable `binance_ws` and its unit tests.
- Updated `.gitignore` to stop ignoring `.vscode/` folder and include VSCode test configurations.
- Refactored `src/main.rs` to handle symbol fetching and error management.
  - `show_menu()` now accepts symbols as a parameter.
  - Improved error handling for fetching symbols.
- Updated `src/menu.rs` to pass symbols to subscription functions.
  - Modified subscription functions to use passed symbols.
  - Introduced constant options and intervals for better readability.
- Modified `src/storage/aggtrade_storage.rs` to return a reference to trades.
- Updated `src/subscription.rs` for clearer URL usage.
  - Changed URLs to constants.
- Refactored `src/websocket/client/run.rs` to use references and improved shutdown handling.
- Adjusted `src/websocket/client/subscribe.rs` and `unsubscribe.rs` to use references for streams.
- Modified `src/websocket/handler/aggtrade_handler.rs` for consistent reference usage.
- Updated `src/websocket/ping.rs` to improve shutdown handling in tests.
- Changed `src/websocket/shutdown.rs` to take shutdown_tx by reference.
- Adjusted `src/websocket/subscriptions.rs` to use references for stream lists.
  - Updated tests to use references.