### PR TITLE
Refactor UI and WebSocket Handling, Switch to Ratatui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ reqwest = { version = "0.12.5", features = ["json"] }
 libc = "0.2"
 term-table = "1.3.2"
 crossterm = "0.27.0"
-tui = "0.19.0"
 chrono = "0.4.38"
+ratatui = "0.27.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is a comprehensive WebSocket client designed to interact with the B
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Usage](#usage)
-   - [Menu Options](#menu-options)
+  - [Menu Options](#menu-options)
 - [Project Structure](#project-structure)
 - [Running Tests](#running-tests)
 - [License](#license)
@@ -30,17 +30,20 @@ This project is a comprehensive WebSocket client designed to interact with the B
 ## Installation
 
 1. Clone the repository:
+
     ```sh
     git clone https://github.com/pedrosfaria2/websocket_binance_api.git
     cd websocket_binance_api
     ```
 
 2. Build the project:
+
     ```sh
     cargo build
     ```
 
 3. Run the tests:
+
     ```sh
     cargo test
     ```
@@ -48,11 +51,10 @@ This project is a comprehensive WebSocket client designed to interact with the B
 ## Usage
 
 1. Run the WebSocket client:
+
     ```sh
     cargo run
     ```
-   
-
 
 2. Follow the on-screen menu to subscribe to various streams.
 3. *Only the AggTrade has been implemented so far!*
@@ -84,6 +86,7 @@ The project is organized into several modules to enhance modularity and maintain
 ## Running Tests
 
 The project includes unit tests for various components. To run the tests, use the following command:
+
 ```sh
 cargo test
 ```

--- a/src/websocket/handler/aggtrade_handler.rs
+++ b/src/websocket/handler/aggtrade_handler.rs
@@ -13,8 +13,8 @@ use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::protocol::Message;
-use tui::backend::CrosstermBackend;
-use tui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
 
 pub async fn handle_aggtrade_messages<S>(
     read: &mut S,
@@ -34,7 +34,7 @@ pub async fn handle_aggtrade_messages<S>(
     // Channel for user input shutdown signal
     let (input_tx, mut input_rx) = mpsc::channel(1);
     tokio::spawn(async move {
-        handle_input(input_tx).await;
+        handle_input(&input_tx).await;
     });
 
     let mut message_count: u64 = 0;
@@ -123,7 +123,7 @@ pub async fn handle_aggtrade_messages<S>(
 
                                 // Draw UI
                                 terminal.draw(|f| {
-                                    render_ui(f, render_data);
+                                    render_ui(f, &render_data);
                                 }).unwrap();
                             }
                         }

--- a/src/websocket/handler/input.rs
+++ b/src/websocket/handler/input.rs
@@ -1,7 +1,7 @@
 use crossterm::event::{self, Event as CEvent, KeyCode};
 use tokio::sync::mpsc;
 
-pub async fn handle_input(shutdown_tx: mpsc::Sender<()>) {
+pub async fn handle_input(shutdown_tx: &mpsc::Sender<()>) {
     loop {
         // Poll for events every 10 milliseconds
         if event::poll(std::time::Duration::from_millis(10)).unwrap() {

--- a/src/websocket/ping.rs
+++ b/src/websocket/ping.rs
@@ -4,7 +4,7 @@ use tokio::sync::oneshot;
 use tokio::time::{interval, Duration};
 use tokio_tungstenite::tungstenite::protocol::Message;
 
-pub async fn start_ping<W>(write: &mut W, shutdown_rx: &mut oneshot::Receiver<()>)
+pub async fn start_ping<W>(write: &mut W, mut shutdown_rx: oneshot::Receiver<()>)
 where
     W: SinkExt<Message> + Unpin,
     <W as futures_util::Sink<Message>>::Error: Debug,
@@ -15,9 +15,8 @@ where
             _ = ping_interval.tick() => {
                 // Send ping message at regular intervals
                 write.send(Message::Ping(Vec::new())).await.unwrap();
-                break;
             },
-            _ = shutdown_rx => {
+            _ = &mut shutdown_rx => {
                 // Shutdown WebSocket connection
                 println!("Shutting down WebSocket...");
                 write.send(Message::Close(None)).await.unwrap();
@@ -78,12 +77,11 @@ mod tests {
     #[tokio::test]
     async fn test_start_ping() {
         let (mut mock_sink, mut rx) = MockSink::new();
-        let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
         tokio::spawn(async move {
-            start_ping(&mut mock_sink, &mut shutdown_rx).await;
+            start_ping(&mut mock_sink, shutdown_rx).await;
         });
-
         tokio::time::sleep(Duration::from_secs(1)).await;
         shutdown_tx.send(()).unwrap();
 


### PR DESCRIPTION
- **Cargo.toml:**
  - Replaced `tui` with `ratatui` for improved terminal UI rendering.

- **README.md:**
  - Fixed markdown formatting.
  - Added spacing for better readability.

- **src/ui/render.rs:**
  - Switched from `tui` to `ratatui` imports.
  - Implemented a macro for creating spans to reduce redundancy.
  - Updated table widget creation and statistics rendering using `ratatui`.
  - Enhanced layout and style definitions for UI components.

- **src/websocket/client/run.rs:**
  - Corrected WebSocket shutdown handling using `ws_shutdown_tx`.
  - Ensured message handling tasks are properly awaited.

- **src/websocket/handler/aggtrade_handler.rs:**
  - Replaced `tui` with `ratatui` imports.
  - Adjusted function calls for rendering and input handling.

- **src/websocket/handler/input.rs:**
  - Changed input handler to take a reference to the shutdown transmitter.

- **src/websocket/ping.rs:**
  - Refined ping handling by making `shutdown_rx` mutable within the function.
  - Updated test cases to align with the new shutdown handling mechanism.